### PR TITLE
fix/death on multi scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ Some class files can't be properly read by the class parser library. It also app
 ## License
 
 Due to the nature of this being a malware detection tool, the permissive MIT license is applied. The only requirement is that you include the copyright notice and the license text as described in [the license file](./LICENSE).
+
+## How To Run
+
+This project is a Vue.js application. Any knowledge about Vue.js should apply here
+
+If anyone wants to run the webserver locally, e.g. for development purposes, they will require nodejs.
+
+After cloning and entering the project folder, the following commands will import the dependencies
+```CMD
+npm install
+```
+and start the app.
+```CMD
+npm run dev
+```


### PR DESCRIPTION
Hi there, sorry to pop into your project like this, but i really wanted to scan All the Mods 8.

Since it ground to a halt after only a dozen or two jars and didn't make any progress overnight,
i decided to iterate over the files one by one instead of handling all of them at once.
Also threw in one loop per cpu core while i was at it.

It took my laptop about 3 hours and 20 minutes to go through the 357 mods, all of which were clear.
Still hangs a bit after marking mods with >1000 classes as clean, but at least now it finishes.

I'm not really sure if this would count as a solution, but my problem was definitely similar to what's mentioned in #4 

Possible Problems:
I'm getting mixed signals about support for navigator.hardwareConcurrency on Safari, though according to w3cub it does still return a number there.
It's also not supported on some mobile browsers, though i doubt many will use this on phones anyway.
